### PR TITLE
fix docker-kafka's configuration in docker-compose.yml.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,10 +41,12 @@ services:
   kafka:
     image: wurstmeister/kafka:2.12-2.2.1
     ports:
-      - "9092"
+      - "9092:9092"
     depends_on:
       - zookeeper
     environment:
+      KAFKA_ADVERTISED_HOST_NAME: "kafka"
+      KAFKA_ADVERTISED_PORT: "9092"
       HOSTNAME_COMMAND: "route -n | awk '/UG[ \t]/{print $$2}'"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_CREATE_TOPICS: "Rides:1:1, Fares:1:1, DriverChanges:1:1"


### PR DESCRIPTION
Hi, I fix docker-kafka's configuration in docker-compose.yml according to the issue https://github.com/wurstmeister/kafka-docker/issues/81. If not, error "org.apache.kafka.common.config.ConfigException: Invalid value for configuration advertised.port: Not a number of type INT" will report when running conmmand "docker-compose up".